### PR TITLE
Fix TODOs in geometry.py

### DIFF
--- a/urdfModifiers/geometry/geometry.py
+++ b/urdfModifiers/geometry/geometry.py
@@ -1,8 +1,7 @@
-from enum import Enum, EnumMeta
+from enum import Enum, EnumMeta, auto
 
-# TODO clean up: add docstring for limbMeta
-# TODO clean up: use enum auto 
-class LimbMeta(EnumMeta):
+class ContainsBasedOnKeyMeta(EnumMeta):
+    """Metaclass for enums that modifies the __contains__ method to check for keys instead of values."""
     def __contains__(cls, item):
         try:
             cls[item]
@@ -12,32 +11,32 @@ class LimbMeta(EnumMeta):
 
 class Geometry(Enum):
     """The different types of geometries that constitute the URDF"""
-    BOX = 1
-    CYLINDER = 2
-    SPHERE = 3
+    BOX = auto()
+    CYLINDER = auto()
+    SPHERE = auto()
 
 class Side(Enum):
     """The possible sides of a box geometry"""
-    WIDTH = 1
-    HEIGHT = 2
-    DEPTH = 3
+    WIDTH = auto()
+    HEIGHT = auto()
+    DEPTH = auto()
 
-class Limb(Enum, metaclass=LimbMeta):
+class Limb(Enum, metaclass=ContainsBasedOnKeyMeta):
     """The possible limbs of the robot"""
-    NONE = 0
-    RIGHT_ARM = 1
-    LEFT_ARM = 2
-    RIGHT_LEG = 3
-    LEFT_LEG = 4
-    ARMS = 5
-    LEGS = 6
-    TORSO = 7
-    ALL = 8
+    NONE = auto()
+    RIGHT_ARM = auto()
+    LEFT_ARM = auto()
+    RIGHT_LEG = auto()
+    LEFT_LEG = auto()
+    ARMS = auto()
+    LEGS = auto()
+    TORSO = auto()
+    ALL = auto()
 
 class RobotElement(Enum):
     """Types of elements in the urdf"""
-    LINK = 1
-    JOINT = 2
+    LINK = auto()
+    JOINT = auto()
 
 class Modification():
     """Available modifications type"""


### PR DESCRIPTION
This PR addresses the TODOs in `geometry.py` regarding the use of enums.

A doctring has been added to explain `LimbMeta`, which has been renamed to `ContainsBasedOnKeyMeta` for clarity.

In case it's not clear what this metaclass does, it modifies the function that is called when one checks for a `if __ in __` condition. For example, in:

```python
class MyEnum(Enum):
    APPLES = 1
    ORANGES = 2
```

We would get the following:

```python
'APPLES' in MyEnum # false
1 in MyEnum # true
```

The `ContainsBasedOnKeyMeta` changes the behavior to:

```python
'APPLES' in MyEnum # true
1 in MyEnum # false
```

Which is useful when, for example, trying to parse a file and turn its content into an enum.

With this change we don't really care about the value of the enums, so we can use the `enum.auto()` function to automatically assign values to the enums (in the end we only care about the keys).