### PR TITLE
Fixed bug when there is no gazebo tag in urdf

### DIFF
--- a/urdfModifiers/utils/utils.py
+++ b/urdfModifiers/utils/utils.py
@@ -8,11 +8,12 @@ from urdfModifiers.geometry.geometry import Modification
 def write_urdf_to_file(urdf, filename, gazebo_plugins):
     """Saves the URDF to a valid .urdf file, also adding the gazebo_plugins"""
     urdf.save(filename)
-    lines = ''
+    lines = []
     with open(filename, 'r') as f:
         lines = f.readlines()
-        lines.pop()
+        last_line = lines.pop()
         lines = lines + gazebo_plugins
+        lines.append(last_line)
 
     with open(filename, 'w') as f:
         f.writelines(lines)
@@ -20,19 +21,20 @@ def write_urdf_to_file(urdf, filename, gazebo_plugins):
 def separate_gazebo_plugins(filename):
     """Splits the URDF content in two parts: one relative to the robot and another to the gazebo plugins"""
     gazebo_lines = []
-    other_lines= []
+    robot_lines= []
     with open(filename, "r") as f:
         lines = f.readlines()
         is_gazebo = False
         for line in lines:
-            if '<gazebo' in line or '< gazebo' in line:
+            if '<gazebo' in line or '<gazebo' in line:
                 is_gazebo = True
             if (is_gazebo):
                 gazebo_lines.append(line)
             else:
-                other_lines.append(line)
-    other_lines.append('</robot>')
-    return [other_lines, gazebo_lines]
+                robot_lines.append(line)
+            if '</gazebo' in line or '< /gazebo' in line:
+                is_gazebo = False
+    return [robot_lines, gazebo_lines]
 
 def create_dummy_file(dummy_filename, text):
     """Creates a dummy file to save information"""

--- a/urdfModifiers/utils/utils.py
+++ b/urdfModifiers/utils/utils.py
@@ -26,7 +26,7 @@ def separate_gazebo_plugins(filename):
         lines = f.readlines()
         is_gazebo = False
         for line in lines:
-            if '<gazebo' in line or '<gazebo' in line:
+            if '<gazebo' in line or '< gazebo' in line:
                 is_gazebo = True
             if (is_gazebo):
                 gazebo_lines.append(line)


### PR DESCRIPTION
In `ergocub_gazebo_simulations` we always expected some `<gazebo>` tags at the end of the URDF. This resulted in several bugs when using a URDF with no such tags. 

This PR solves these bugs, and makes the library work with and without `<gazebo>` tags. Plus, they don't need to be at the end of the URDF (they will be written at the end in the output file however).

cc @traversaro 