### PR TITLE
Fix Python package name in one-line install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Clone the repo and install the library:
 
 ```bash
 
-pip install "urdf-modifiers @ git+https://github.com/icub-tech-iit/urdf-modifiers"
+pip install "urdfModifiers @ git+https://github.com/icub-tech-iit/urdf-modifiers"
 
 ```
 


### PR DESCRIPTION
The name of the repo is `urdf-modifiers`, but the Python package name is `urdfModifiers`. Before this modification, running the command resulted in this warning printed:
~~~
  WARNING: Generating metadata for package urdf-modifiers produced metadata for project name urdfmodifiers. Fix your #egg=urdf-modifiers fragments.
~~~