### PR TITLE
Fix use urdfModifiers.core.modification.Modification

### DIFF
--- a/urdfModifiers/core/__init__.py
+++ b/urdfModifiers/core/__init__.py
@@ -3,6 +3,7 @@
 # GNU Lesser General Public License v2.1 or any later version.
 
 from . import modifier
+from . import modification
 from . import linkModifier
 from . import jointModifier
 


### PR DESCRIPTION
I tried to port the example mentioned in https://github.com/icub-tech-iit/urdf-modifiers/issues/11 to the new API, but I had a problem to use the new class as `urdfModifiers.core.modification.Modification` . This fixes the problem.