### PR TITLE
Add version to metadata in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,7 @@ name = urdfModifiers
 description = library to modify urdf 
 author = "TODO"
 author_email = TODO
+version = 0.0.2
 
 [options]
 packages = find:


### PR DESCRIPTION
Without this values, if a user installs the library from a tag like https://github.com/icub-tech-iit/urdf-modifiers/releases/tag/v0.0.1 and then runs `pip list`, the library get listed as version `0.0.0`:
~~~
(umdev) traversaro@IITICUBLAP257:~/urdf-modifiers$ pip list
Package         Version
--------------- -------
dataclasses     0.6
decorator       5.1.1
freetype-py     2.2.0
idyntree        5.0.0
imageio         2.16.0
lxml            4.8.0
networkx        2.2
numpy           1.22.2
Pillow          9.0.1
pip             22.0.3
pycollada       0.6
pyglet          1.5.21
PyOpenGL        3.1.0
pyrender        0.1.45
python-dateutil 2.8.2
scipy           1.8.0
setuptools      60.9.3
six             1.16.0
trimesh         3.10.1
urdfModifiers   0.0.0
urdfpy          0.0.22
wheel           0.37.1
~~~

Currently I set the version to 0.0.2 as I imagine that this will be the next version, but feel free to change that.