### PR TITLE
Add joint type

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The possible modifications are related to :
 - **Dimension** (relative and absolute)
 - **Radius** (relative and absolute)
 - **Position** (relative and absolute)
+- **Joint type** (_revolute_, _prismatic_, _continuous_, _fixed_)
 
 An interface for reading the modifications from a configuration file is provided together with the library.
 
@@ -170,6 +171,9 @@ density_scale = 1.5
 
 [r_lower_leg]
 position_scale = 2.0
+
+[l_ankle_roll]
+joint_type = 'fixed'
 ```
 
 The suffix `_scale` referes to relative modifications (so `absolute=False` when creating the modifier).

--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ joint_modifications.add_position(0.4, absolute=True)
 link_modifier.modify(link_modifications)
 joint_modifier.modify(joint_modifications)
 
+# Create a new Modification instance 
+joint_modification_joint_type = Modification()
+joint_modification_joint_type.add_joint_type(geometry.JointType.REVOLUTE)
+
+# Apply the modification 
+joint_modifier.modify(joint_modification_joint_type)
+
 # Write URDF to a new file, also adding back the previously removed <gazebo> tags                
 utils.write_urdf_to_file(robot, output_file, gazebo_plugin_text)  
 ```

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -6,7 +6,7 @@ from urdfModifiers.core.jointModifier import JointModifier
 from urdfModifiers.core.fixedOffsetModifier import FixedOffsetModifier
 from urdfModifiers.geometry import *
 from urdfModifiers.utils import *
-from urdfpy import matrix_to_xyz_rpy 
+from urdfpy import Joint, matrix_to_xyz_rpy 
 import math
 
 """
@@ -1019,6 +1019,14 @@ class FixedOffsetModifierTests(unittest.TestCase):
         
         self.assertEqual(modified_parent_joint_offset,
                          None)
+
+    def test_joint_type(self):
+        modifier = JointModifier.from_name("aligned_link_joint_after", self.modified_robot) 
+        modification = Modification()
+        modification.add_joint_type('revolute')
+        modifier.modify(modification)
+        modified_joint = [joint for joint in self.modified_robot.joints if joint.name == 'aligned_link_joint_after'][0]
+        self.assertEqual(modified_joint.joint_type, 'revolute')
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -6,7 +6,7 @@ from urdfModifiers.core.jointModifier import JointModifier
 from urdfModifiers.core.fixedOffsetModifier import FixedOffsetModifier
 from urdfModifiers.geometry import *
 from urdfModifiers.utils import *
-from urdfpy import Joint, matrix_to_xyz_rpy 
+from urdfpy import matrix_to_xyz_rpy 
 import math
 
 """

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1023,10 +1023,10 @@ class FixedOffsetModifierTests(unittest.TestCase):
     def test_joint_type(self):
         modifier = JointModifier.from_name("aligned_link_joint_after", self.modified_robot) 
         modification = Modification()
-        modification.add_joint_type('revolute')
+        modification.add_joint_type(geometry.JointType.REVOLUTE)
         modifier.modify(modification)
         modified_joint = [joint for joint in self.modified_robot.joints if joint.name == 'aligned_link_joint_after'][0]
-        self.assertEqual(modified_joint.joint_type, 'revolute')
+        self.assertEqual(modified_joint.joint_type, geometry.JointType.REVOLUTE)
 
 if __name__ == '__main__':
     unittest.main()

--- a/urdfModifiers/core/jointModifier.py
+++ b/urdfModifiers/core/jointModifier.py
@@ -48,4 +48,7 @@ class JointModifier(modifier.Modifier):
                 elif (self.axis == Side.Z):
                     xyz_rpy[2] = original_z * modifications.position.value
             self.element.origin = xyz_rpy_to_matrix(xyz_rpy) 
+            
+        if modifications.joint_type: 
+            self.element.joint_type = modifications.joint_type
                 

--- a/urdfModifiers/core/modification.py
+++ b/urdfModifiers/core/modification.py
@@ -19,6 +19,7 @@ class Modification:
         self.dimension = None
         self.radius = None
         self.position = None
+        self.joint_type = None 
         pass
 
     @classmethod
@@ -61,6 +62,11 @@ class Modification:
         if position is not None:
             new_modification.add_position(float(position), True)
 
+        joint_type_modification = config_section.get('joint_type', None)
+        
+        if(joint_type_modification): 
+            new_modification.add_joint_type(str(joint_type_modification))
+
         return new_modification
 
     def add_density(self, value, absolute):
@@ -83,6 +89,9 @@ class Modification:
         """Adds a modification of the position of the origin"""
         self.position = ModificationType(value, absolute)
 
+    def add_joint_type(self, value):
+        self.joint_type = value
+
     def __str__(self):
         print_message = "Modification class with the following parameters: "
         if self.mass:
@@ -95,5 +104,6 @@ class Modification:
             print_message += f"{'Absolute' if self.radius.absolute else 'Relative'} modification of radius with value {self.radius.value}. "
         if self.position:
             print_message += f"{'Absolute' if self.position.absolute else 'Relative'} modification of origin position with value {self.position.value}."
-        
+        if self.joint_type: 
+            print_message += f"Joint Type "+ self.joint_type
         return print_message

--- a/urdfModifiers/core/modification.py
+++ b/urdfModifiers/core/modification.py
@@ -63,7 +63,7 @@ class Modification:
             new_modification.add_position(float(position), True)
 
         joint_type_modification = config_section.get('joint_type', None)
-        
+
         if(joint_type_modification): 
             new_modification.add_joint_type(str(joint_type_modification))
 
@@ -107,3 +107,4 @@ class Modification:
         if self.joint_type: 
             print_message += f"Joint Type "+ self.joint_type
         return print_message
+        

--- a/urdfModifiers/geometry/geometry.py
+++ b/urdfModifiers/geometry/geometry.py
@@ -21,6 +21,13 @@ class Side(Enum):
     Y = auto()
     Z = auto()
 
+class JointType():
+    """The different types of joint"""
+    PRISMATIC = 'prismatic'
+    REVOLUTE = 'revolute'
+    FIXED = 'fixed'
+    CONTINUOUS = 'continuous'
+
 class Limb(Enum, metaclass=ContainsBasedOnKeyMeta):
     """The possible limbs of the robot"""
     NONE = auto()


### PR DESCRIPTION
This PR addresses #22. The changes have been ported only to the joint modifier class since the fixed offset class takes into account only the links and changes the joints to maintain a fixed offset. 

C.C. @GrmanRodriguez @AlexAntn @traversaro @fabiodinatale