### PR TITLE
Add support for non-Z-aligned links in FixedOffsetMultiplier

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,6 @@ However, for **dimension** modifications it will also adjust the origin of both 
 
 ![FixedOffset Explanation](./assets/fomodifier.png)
 
-This modifier will only work if the origin of parent joint, link and child joint are parallel with respect to the Z axis.
-
 ```python
 from urdfModifiers.core.fixedOffsetModifier import FixedOffsetModifier
 from urdfModifiers.core.modification import Modification

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -992,6 +992,39 @@ class FixedOffsetModifierTests(unittest.TestCase):
             self.assertEqual(modified_child_joint_offset[index],
                             child_joint_offset[index])
 
+    def test_offset_mask_for_non_aligned_joint(self):
+
+        modifier = FixedOffsetModifier.from_name('non_aligned_link', self.modified_robot)
+
+        modification = Modification()
+        modification.add_dimension(3, offset_mask=[0,0,1], absolute=True)
+
+        parent_joint_offset, child_joint_offset = modifier.calculate_offsets()
+
+        modifier.modify(modification)
+
+        modified_parent_joint_offset, modified_child_joint_offset = modifier.calculate_offsets()
+
+        modified_link = [link for link in self.modified_robot.links if link.name == 'non_aligned_link'][0]
+
+        self.assertEqual(modified_link.visuals[0].geometry.box.size[2],
+                         3)
+
+        self.assertAlmostEqual(modified_parent_joint_offset.z,
+                         parent_joint_offset.z)
+        self.assertNotAlmostEqual(modified_parent_joint_offset.x,
+                         parent_joint_offset.x)
+        self.assertNotAlmostEqual(modified_parent_joint_offset.y,
+                         parent_joint_offset.y)
+
+        for index in range(len(child_joint_offset)):
+            self.assertAlmostEqual(modified_child_joint_offset[index].z,
+                            child_joint_offset[index].z)
+            self.assertNotAlmostEqual(modified_child_joint_offset[index].x,
+                            child_joint_offset[index].x)
+            self.assertNotAlmostEqual(modified_child_joint_offset[index].y,
+                            child_joint_offset[index].y)
+
     def test_works_with_no_child_joint(self):
 
         modifier = FixedOffsetModifier.from_name('connector_link_2', self.modified_robot)

--- a/urdfModifiers/core/fixedOffsetModifier.py
+++ b/urdfModifiers/core/fixedOffsetModifier.py
@@ -265,10 +265,10 @@ class FixedOffsetModifier():
         link_rotation_matrix, link_translation_vector = self.split_transformation_matrix(link_origin_matrix)
         for item in child_joint_offset:
             # j_o' = s_o + v_l' * sign(j_o) - e_o
-                new_child_origin_position = - item.to_vector() + link_translation_vector + new_length / 2 * np.dot(link_rotation_matrix, unit_vector)
+            new_child_origin_position = - item.to_vector() + link_translation_vector + new_length / 2 * np.dot(link_rotation_matrix, unit_vector)
         
-                corresponding_modifier = [joint_modifier for joint_modifier in self.joint_modifier_list if joint_modifier.element == item.joint][0]
-                self.modify_origin_three_dimensions(corresponding_modifier, new_child_origin_position, offset_mask)
+            corresponding_modifier = [joint_modifier for joint_modifier in self.joint_modifier_list if joint_modifier.element == item.joint][0]
+            self.modify_origin_three_dimensions(corresponding_modifier, new_child_origin_position, offset_mask)
 
     def modify_origin_three_dimensions(self, modifier, new_position, offset_mask=[1,1,1]):
         """Performs 3 position modifications to place the origin in a new X, Y and Z"""

--- a/urdfModifiers/core/fixedOffsetModifier.py
+++ b/urdfModifiers/core/fixedOffsetModifier.py
@@ -38,7 +38,7 @@ class Offset():
 @dataclass
 class FixedOffsetModifier():
     """
-    Class to modify link that is Z-parallel with its previous and following joints, while keeping the offsets
+    Class to modify link with its previous and following joints, while keeping the offsets
     
         --- +-----------+ -
         ^   |           | ^
@@ -63,49 +63,28 @@ class FixedOffsetModifier():
                 parent
 
     Considering the above link, we define the following values:
-    s_o - distance between the link frame (the parent origin referential) and the start of the link visual element      - parent_joint_offset
-    e_o - distance between the child link frame (the child origin referential) and the end of the link visual element   - child_joint_offset
+    s_o - vector between the link frame (the parent origin referential) and the start of the link visual element      - parent_joint_offset
+    e_o - vector between the child link frame (the child origin referential) and the end of the link visual element   - child_joint_offset
 
-    j_o - distance between the axis connecting the link to its parent and the axis connecting the link to its child     - child_joint_origin
+    j_o - vector between the axis connecting the link to its parent and the axis connecting the link to its child     - child_joint_origin
     v_l - length of the visual element (box or cylinder) of the link                                                    - link_length
-    v_o - distance between the link frame and the center of the visual element                                          - link_visual_origin
+    v_o - vector between the link frame and the center of the visual element                                          - link_visual_origin
 
     Using these definitions, we can relate them using the following formulas:
 
-    s_o = v_o - v_l * sign(j_o) / 2
-    e_o = v_o + v_l * sign(j_o) / 2 - j_o
+    s_o = v_o - v_l * j_o / 2
+    e_o = v_o + v_l * j_o / 2 - j_o
 
     Using these formulas, and assuming we want to keep the values s_o and e_o constant, a modification of the link length would lead 
     to a known change of v_l, which we define as v_l'. Knowing v_l', s_o and e_o we compute the 2 remaining values, v_o' and j_o', therefore completely defining
     the origin of both the link visual and the child joint:
 
-    v_o' = s_o + v_l' * sign(j_o) / 2
-    j_o' = v_o' - e_o + v_l' * sign(j_o) / 2
+    v_o' = s_o + v_l' * j_o / 2
+    j_o' = v_o' - e_o + v_l' * j_o / 2
 
     or, solving for v_o'
 
-    j_o' = s_o + v_l' * sign(j_o) - e_o
-
-    IMPORTANT NOTE:
-    This fixed offset modification only works for z-parallel links, that is, when the parent joint, link and child joint XY planes are all parallel:
-
-      /--^----/
-     /   |   /     child XY plane
-    /-------/
-
-        /--^----/
-       /   |   /   link XY plane
-      /-------/
-
-      /--^----/
-     /   |   /     parent XY plane
-    /-------/
-
-    if the link you are changing is not z-parallel, you should instead use the API available in JointModifier and LinkModifier
-            
-    For more details regarding the calculation of these values, you can check the following link:
-    https://github.com/icub-tech-iit/urdf-modifiers/issues/11
-    
+    j_o' = s_o + v_l' * j_o - e_o    
     """
 
     def __init__(self, link, robot, axis=Side.Z):

--- a/urdfModifiers/core/fixedOffsetModifier.py
+++ b/urdfModifiers/core/fixedOffsetModifier.py
@@ -166,14 +166,14 @@ class FixedOffsetModifier():
         return significant_length
 
     def get_joint_origin(self, joint, transform = True):
-        """Returns the origin of a joint w.r.t. to the link frame"""
+        """Returns the origin of a joint w.r.t. to the link's frame"""
         if not joint:
             return None
         
         return (matrix_to_xyz_rpy(joint.origin) if transform else joint.origin)
 
     def get_link_origin(self, link, transform = True):
-        """Returns the origin of a first visual element w.r.t. to the link frame"""
+        """Returns the origin of the first visual element w.r.t. to the link's frame"""
         link_origin = matrix_to_xyz_rpy(link.visuals[0].origin) if transform else link.visuals[0].origin
         return link_origin
 

--- a/urdfModifiers/core/modification.py
+++ b/urdfModifiers/core/modification.py
@@ -20,6 +20,7 @@ class Modification:
         self.radius = None
         self.position = None
         self.joint_type = None 
+        self.offset_mask = [1,1,1]
         pass
 
     @classmethod
@@ -73,9 +74,18 @@ class Modification:
         """Adds a modification of the density"""
         self.density = ModificationType(value, absolute)
 
-    def add_dimension(self, value, absolute):
+    def add_dimension(self, value, absolute, offset_mask=None):
         """Adds a modification of the main dimension"""
         self.dimension = ModificationType(value, absolute)
+        if offset_mask is not None:
+            self.add_offset_mask(offset_mask)
+
+    def add_offset_mask(self, offset_mask):
+        """Changes the offset mask for choosing which offsets to keep.
+        Mask should be an array of 3 truthy/falsy values representing each axis"""
+        if not isinstance(offset_mask, list) or len(offset_mask) != 3:
+            raise Exception("Invalid Offset Mask parameter, expected array with 3 values")
+        self.offset_mask = offset_mask
 
     def add_mass(self, value, absolute):
         """Adds a modification of the mass"""
@@ -90,6 +100,7 @@ class Modification:
         self.position = ModificationType(value, absolute)
 
     def add_joint_type(self, value):
+        """Adds a modification of the type of joint (revolute, fixed, etc)"""
         self.joint_type = value
 
     def __str__(self):

--- a/urdfModifiers/utils/utils.py
+++ b/urdfModifiers/utils/utils.py
@@ -3,7 +3,7 @@ from urdfpy import URDF
 from urdfModifiers.geometry import *
 import os
 
-def write_urdf_to_file(urdf, filename, gazebo_plugins):
+def write_urdf_to_file(urdf, filename, gazebo_plugins=[]):
     """Saves the URDF to a valid .urdf file, also adding the gazebo_plugins"""
     urdf.save(filename)
     lines = []


### PR DESCRIPTION
This PR expands the functionality of the FixedOffsetMultiplier by removing the restriction that the links must be Z-aligned.

This is done by expanding the previous method of calculation into the 3 dimension vectorial space:

![non-z-aligned-1](https://user-images.githubusercontent.com/31577366/166250003-11c732f7-8ee7-4854-b0d9-9218bdbde59a.png)

We define ô as the unitary vector pointing to the positive direction of change. For cylinders this vector points to the positive Z axis of the link, while on box geometries it depends on the axis of elongation.

We define the start of the link as the point of the link furthest away in the negative ô direction. The end of the link is the point furthest away in the positive ô direction.

The offsets then become the vector between the parent joint and the start (PS) and the vector between the child joint and the end (CE).

To calculate PS we use the following formula:

![non-z-aligned-2](https://user-images.githubusercontent.com/31577366/166251235-16dd6d0e-d1be-42f6-a1a9-c1a6e69c34ce.png)

**PS = PO - Vl/2 * ô**

Similarly, to find the link origin PO given an offset we can rewrite the equation to **PO = PS +  Vl/2 * ô**

To calculate CE we use the following:

![non-z-aligned-3](https://user-images.githubusercontent.com/31577366/166251785-6d28a855-6f39-4bc5-b3af-badaaf1213bf.png)

PC + CE = PO + Vl/2 * ô    --->   **CE = PO + Vl/2 * ô - PC**

To find the origin of the child joint given an offset we rewrite it to **PC = PO + Vl/2 * ô - CE**

To find ô, PO and PC, the `urdfpy` library gives us the transformation matrix between from P to O and from P to C:

```
O = [[R_o, t_o], * P
     [1  , 0  ]]

C = [[R_c, t_c], * P
     [1  , 0  ]]
```

From where it's easy to find that **PO = t_o**, **PC = t_c** and **ô = R_o * [0,0,1]** (for elongation in Z).

### Results:

Here is an example of the result:

```python
modifier = FixedOffsetModifier.from_name('non_aligned_link', self.modified_robot)

modification = Modification()
modification.add_dimension(3, absolute=True)

modifier.modify(modification)
```

![image_7](https://user-images.githubusercontent.com/31577366/166253700-2db03f6f-8d35-4b7e-8fff-f34822568211.jpeg)

We also allow the option to only move in some axes and not others, by using mask:

```python
modifier = FixedOffsetModifier.from_name('non_aligned_link', self.modified_robot)

modification = Modification()
modification.add_dimension(3, offset_mask=[0,0,1], absolute=True) # only move in Z direction

modifier.modify(modification)
```

![MicrosoftTeams-image (1)](https://user-images.githubusercontent.com/31577366/166254654-45d81992-be84-4f46-8a6d-0f9f4b20c8f3.png)