### PR TITLE
Migrate from urdfpy to urchin

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If you want to convert your model into basic shapes, you can use [`idyntree-mode
 
 Other requisites are:
 
-- [`urdfpy`](https://github.com/mmatl/urdfpy)
+- [`urchin`](https://github.com/fishbotics/urchin)
 - [`dataclasses`](https://pypi.org/project/dataclasses/)
 - [`unittest`](https://pypi.org/project/unittest/)
 

--- a/examples/stickBotModification.ipynb
+++ b/examples/stickBotModification.ipynb
@@ -10,7 +10,7 @@
     "from urdfModifiers.core.jointModifier import JointModifier\n",
     "from urdfModifiers import utils\n",
     "from urdfModifiers.core.modification import Modification\n",
-    "from urdfpy import URDF\n",
+    "from urchin import URDF\n",
     "from urdfModifiers.geometry import * \n",
     "from urdfModifiers.geometry.geometry import Side\n",
     "from urdfModifiers.utils import *\n",

--- a/examples/stickBotModificationFromConfFile.ipynb
+++ b/examples/stickBotModificationFromConfFile.ipynb
@@ -9,7 +9,7 @@
     "from urdfModifiers.core.linkModifier import LinkModifier\n",
     "from urdfModifiers.core.jointModifier import JointModifier\n",
     "from urdfModifiers import utils\n",
-    "from urdfpy import URDF\n",
+    "from urchin import URDF\n",
     "from urdfModifiers.geometry import * \n",
     "from urdfModifiers.geometry.geometry import Side\n",
     "from urdfModifiers.utils import *\n",

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ version = 0.0.2
 packages = find:
 python_requires = >=3.7
 install_requires =
-        urdfpy
+        urchin
         numpy
         dataclasses
         idyntree

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -7,7 +7,7 @@ from urdfModifiers.core.fixedOffsetModifier import FixedOffsetModifier
 from urdfModifiers.geometry import *
 from urdfModifiers.geometry.geometry import Side
 from urdfModifiers.utils import *
-from urdfpy import matrix_to_xyz_rpy 
+from urchin import matrix_to_xyz_rpy 
 import math
 
 """

--- a/urdfModifiers/core/fixedOffsetModifier.py
+++ b/urdfModifiers/core/fixedOffsetModifier.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from urdfpy import matrix_to_xyz_rpy
+from urchin import matrix_to_xyz_rpy
 from math import isclose
 import numpy as np
 from urdfModifiers.core.jointModifier import JointModifier

--- a/urdfModifiers/core/jointModifier.py
+++ b/urdfModifiers/core/jointModifier.py
@@ -1,6 +1,6 @@
 from urdfModifiers.core import modifier
 from urdfModifiers.geometry.geometry import *
-from urdfpy import xyz_rpy_to_matrix, matrix_to_xyz_rpy 
+from urchin import xyz_rpy_to_matrix, matrix_to_xyz_rpy 
 
 class JointModifier(modifier.Modifier):
     """Class to modify joints in a URDF"""

--- a/urdfModifiers/core/linkModifier.py
+++ b/urdfModifiers/core/linkModifier.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from urdfpy import xyz_rpy_to_matrix, matrix_to_xyz_rpy
+from urchin import xyz_rpy_to_matrix, matrix_to_xyz_rpy
 from urdfModifiers.core import modifier
 import math
 import numpy as np

--- a/urdfModifiers/utils/utils.py
+++ b/urdfModifiers/utils/utils.py
@@ -1,5 +1,5 @@
 from typing import Tuple
-from urdfpy import URDF
+from urchin import URDF
 from urdfModifiers.geometry import *
 import os
 


### PR DESCRIPTION
The `urdfpy` project has problems with recent versions of Python and NumPy, and PRs that fix these problems are not merged upstream. For this reason some members community created a friendly fork called "urchin" that provides the same functionality of urdfpy, but fixing the problems with recent versions of Python and NumPy, see https://github.com/mmatl/urdfpy/issues/31 .

This PR migrates urdf-modifiers to use urchin instead of urdfpy, to fix the problems wit recent versions of Python and NumPy. 

Fix https://github.com/icub-tech-iit/urdf-modifiers/issues/31 .
Fix https://github.com/icub-tech-iit/urdf-modifiers/issues/30 .