### PR TITLE
Fix pypi-publish action release name and Actions parameters

### DIFF
--- a/.github/workflows/pypi-ci.yml
+++ b/.github/workflows/pypi-ci.yml
@@ -46,6 +46,11 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [build_wheels]
     if: startsWith(github.ref, 'refs/tags')
+    # Specifying a GitHub environment is optional, but strongly encouraged
+    environment: release
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -55,5 +60,3 @@ jobs:
 
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/pypi-ci.yml
+++ b/.github/workflows/pypi-ci.yml
@@ -54,6 +54,6 @@ jobs:
           path: dist
 
       - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@v1
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Not sure why I used `pypa/gh-action-pypi-publish@v1`, the correct one is `pypa/gh-action-pypi-publish@release/v1`.

Furthermore, modify the Actions parameters to match the one expected for publishing with a Trusted Publisher, see https://docs.pypi.org/trusted-publishers/using-a-publisher/ .