### PR TITLE
Update installation instructions to mention conda and force users to use venv on apt

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,27 +33,30 @@ They will be installed in the installation step!
 
 ## :floppy_disk: Installation
 
-Install `python3`, if not installed (in **Ubuntu 20.04**):
+### Installation on Ubuntu with `apt`
+
+Install `python` and required tools, if not installed:
 
 ```bash
-sudo apt install python3.8
+sudo apt install python3 python3-venv python3-pip
 ```
 
- Install the library via pip:
+ Install the library in a [virtual environment](https://docs.python.org/3/library/venv.html#venv-def), to avoid interfering with the global system:
 
 ```bash
-
-pip install urdf-modifiers  
-
-```
-
-preferably in a [virtual environment](https://docs.python.org/3/library/venv.html#venv-def). For example:
-
-```bash
-pip install virtualenv
 python3 -m venv your_virtual_env
 source your_virtual_env/bin/activate
+pip install urdf-modifiers  
 ```
+
+### Installation on Linux/macOS/Windows with `conda`
+
+Create an environment with `urdf-modifiers`:
+
+~~~
+conda create -n urdfmodifiersenv urdf-modifiers
+conda activate urdfmodifiersenv
+~~~
 
 ## :rocket: Usage
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ pip install urdf-modifiers
 
 Create an environment with `urdf-modifiers`:
 
-~~~
+~~~console
 conda create -n urdfmodifiersenv urdf-modifiers
 conda activate urdfmodifiersenv
 ~~~


### PR DESCRIPTION
Fix https://github.com/icub-tech-iit/urdf-modifiers/issues/40 .

Main modifications:
* On apt, always show installation inside a `venv`. Installing with a naked `pip install` outside of an environment may install a too recent `numpy`, `idyntree` or `scipy` on `~/.local` or even worse `/usr/local`, that could interfere with apt packages or the robotology-superbuild. Let's just keep default options (that users not familiar with Python just copy&paste blindly) safe. More advanced users will know what to do if needed.
* Mention the newly created `urdf-modifiers` conda package (added in https://github.com/conda-forge/staged-recipes/pull/28004)


fyi @CarlottaSartore @Nicogene @claudia-lat @giulioromualdi